### PR TITLE
[build] Integration-testing-fix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,4 +76,5 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
+        arch: x86_64
         script: flutter test integration_test

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false


### PR DESCRIPTION
Identified problems with the pipeline:

1. reactivecircus/android-emulator-runner@v2: when you omit arch, it defaults to x86 — the 32-bit Intel ABI.
   This default was fine years ago but the action kept it for backwards compatibility.
1. Flutter (stable channel): has dropped support for 32-bit x86. In flutter_tools/src/android/android_device.dart,
   the ABI→platform mapping is:
   arm64-v8a → android_arm64
   armeabi-v7a → android_arm
   x86_64 → android_x64
   (anything else, including bare x86) → TargetPlatform.unsupported

The emulator boots fine — that's a KVM/Android concern, not a Flutter one.
But when flutter test integration_test scans for a deploy target, it sees ABI x86, falls through
to the default branch, tags the device unsupported, and exits with "No supported devices connected."
Then, job fails.

Adding `arch: x86_64` pins the emulater to the 64-bit Intel ABI, which will map to `android_x64`.

Identifed problem with the testing process:

Jetifier is a Gradle artifact transform that rewrites legacy android.support.*bytecode into androidx.*.
It loads each dependency JAR fully into memory.
The Flutter engine JAR (io.flutter:x86_64_debug) is large enough that the transform exhausts the 1.5GB
heap on the GitHub runner and aborts with java.nio.file.Files$...Java heap space.

Jetifier is obsolete for this project: every dependency in pubspec.yaml is AndroidX-native
(As per research, Flutter itself has been AndroidX-only since 2020;).
Nothing in the dependency graph references the old android.support.\* packages,
so the Jetifier transform does work that nobody needs — and in CI it does that work until it OOMs.
