### PR TITLE
[fix] revert-package-version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: "direct main"
     description:
       name: download_assets
-      sha256: ab479ef705819783af9c2a53de9c033ac7f621677f250ad0d63728f260d16585
+      sha256: ecc0e9f644f1c57e5ba8c723b05e69ace7fd6177f34eebcadc496b7d410e6c4d
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -399,14 +399,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  idb_shim:
-    dependency: transitive
-    description:
-      name: idb_shim
-      sha256: "6cd94b71a33f1223b01ea2b359c3a6fde5980872b23b31d176a64c74d4dede57"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.5+2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -716,14 +708,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  sembast:
-    dependency: transitive
-    description:
-      name: sembast
-      sha256: "139cf71496105de32e7a08a4e3a1ead0f81c4a616ec9703ed07e8f0d10cdd505"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.8.6"
   share_plus:
     dependency: "direct main"
     description:
@@ -905,14 +889,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   flutter_html: ^3.0.0
   flutter_html_table: ^3.0.0
   path_provider: ^2.0.11
-  download_assets: ^4.1.0
+  download_assets: 4.0.0 # the Content-Length check breaks GitHub archive URLs in 4.1.0
   path: ^1.8.2
   http: ^1.0.0
   dio: ^5.0.0


### PR DESCRIPTION
## What?

It was necessary to revert an upgrade due to a crash
that happens for our app.

I investigated on how to replace the package, but to fix it for now
I only changed the package version.
Further investigation will come soon, on how can we migrate this
dependency, if it's possible to remove it or not.

## Why?

The update of the package cause an unexpected side effect for our
specific use case of how we download files from GitHub.

Due to our source not providing a specific header regarding
the total size of the package, the latest version of the code
rejects it and we can't download anything from GitHub

## How?

For now I have reverted the dependency to a previous version.

## Testing?

## Screenshots (optional)

## Anything Else?
